### PR TITLE
fix(docker): update Go version from 1.22 to 1.24 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
go.mod requires go >= 1.24, matching Dockerfile.dev