### PR TITLE
fix(cors): register middleware via mux.Use to handle preflight requests

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,8 +53,14 @@ func conversationsHandler(proxy *httputil.ReverseProxy) http.HandlerFunc {
 	}
 }
 
-func newRouter(messagingProxy *httputil.ReverseProxy) *mux.Router {
+func newRouter(messagingProxy *httputil.ReverseProxy, corsOrigin string) *mux.Router {
 	r := mux.NewRouter()
+
+	if corsOrigin != "" {
+		r.Use(corsMiddleware(corsOrigin))
+		log.Printf("[CORS] Middleware active with origin %q", corsOrigin)
+	}
+
 	r.HandleFunc("/health", healthHandler).Methods("GET")
 	r.HandleFunc("/ready", readyHandler).Methods("GET")
 	r.PathPrefix("/conversations").HandlerFunc(conversationsHandler(messagingProxy))
@@ -79,28 +85,28 @@ func main() {
 	messagingProxy := httputil.NewSingleHostReverseProxy(messagingTarget)
 	log.Printf("Messaging proxy configured → %s", messagingURL)
 
-	r := newRouter(messagingProxy)
-
 	// CORS configuration
 	appEnv := os.Getenv("APP_ENV")
 	log.Printf("[ENV] APP_ENV=%q", appEnv)
-	var handler http.Handler = r
+	var corsOrigin string
 	if appEnv == "development" {
 		log.Println("[ENV] Development mode: CORS accepting all origins")
-		handler = corsMiddleware("*")(r)
+		corsOrigin = "*"
 	} else {
 		clientURL := os.Getenv("CLIENT_URL")
 		if clientURL != "" {
 			log.Printf("[ENV] Production mode: CORS accepting origin %q", clientURL)
-			handler = corsMiddleware(clientURL)(r)
+			corsOrigin = clientURL
 		} else {
 			log.Println("[ENV] Production mode: CLIENT_URL not set, CORS middleware not active")
 		}
 	}
 
+	r := newRouter(messagingProxy, corsOrigin)
+
 	srv := &http.Server{
 		Addr:         ":" + port,
-		Handler:      handler,
+		Handler:      r,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -188,7 +188,7 @@ func TestConversationsHandler_PostRequest(t *testing.T) {
 func TestNewRouter_HealthRoute(t *testing.T) {
 	backendURL, _ := url.Parse("http://localhost:9999")
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	router := newRouter(proxy)
+	router := newRouter(proxy, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
@@ -211,7 +211,7 @@ func TestNewRouter_HealthRoute(t *testing.T) {
 func TestNewRouter_ReadyRoute(t *testing.T) {
 	backendURL, _ := url.Parse("http://localhost:9999")
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	router := newRouter(proxy)
+	router := newRouter(proxy, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
 	rec := httptest.NewRecorder()
@@ -231,7 +231,7 @@ func TestNewRouter_ConversationsRoute(t *testing.T) {
 
 	backendURL, _ := url.Parse(backend.URL)
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	router := newRouter(proxy)
+	router := newRouter(proxy, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/conversations", nil)
 	rec := httptest.NewRecorder()
@@ -251,7 +251,7 @@ func TestNewRouter_ConversationsSubpath(t *testing.T) {
 
 	backendURL, _ := url.Parse(backend.URL)
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	router := newRouter(proxy)
+	router := newRouter(proxy, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/conversations/123/messages", nil)
 	rec := httptest.NewRecorder()
@@ -266,7 +266,7 @@ func TestNewRouter_ConversationsSubpath(t *testing.T) {
 func TestNewRouter_UnknownRoute(t *testing.T) {
 	backendURL, _ := url.Parse("http://localhost:9999")
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	router := newRouter(proxy)
+	router := newRouter(proxy, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/unknown", nil)
 	rec := httptest.NewRecorder()
@@ -281,7 +281,7 @@ func TestNewRouter_UnknownRoute(t *testing.T) {
 func TestHealthHandler_MethodNotAllowed(t *testing.T) {
 	backendURL, _ := url.Parse("http://localhost:9999")
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	router := newRouter(proxy)
+	router := newRouter(proxy, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/health", nil)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
CORS middleware was wrapping the router externally, causing Gorilla Mux to intercept OPTIONS requests before CORS headers could be set. Moving it to r.Use() ensures it runs before route matching.