### PR TITLE
fix(gateway): apply CORS at server level and fix subrouter route matc…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,17 +60,10 @@ func corsMiddleware(allowedOrigin string) func(http.Handler) http.Handler {
 func buildRouter(cfg *config.Config, authMiddleware JWTValidator) *mux.Router {
 	// Initialiser les proxies
 	authProxy := proxy.NewAuthProxy(cfg.AuthServiceURL)
-	userProxy := proxy.NewServiceProxy(cfg.UserServiceURL)
-	messagingProxy := proxy.NewServiceProxy(cfg.MessagingServiceURL)
+	userProxy := proxy.NewServiceProxy(cfg.UserServiceURL, "/api/v1")
+	messagingProxy := proxy.NewServiceProxy(cfg.MessagingServiceURL, "/api/v1")
 
 	r := mux.NewRouter()
-
-	// CORS middleware
-	corsOrigin := resolveCORSOrigin(cfg)
-	if corsOrigin != "" {
-		r.Use(corsMiddleware(corsOrigin))
-		log.Printf("[CORS] Middleware active with origin %q", corsOrigin)
-	}
 
 	// Routes publiques (health checks)
 	r.HandleFunc("/health", healthHandler).Methods("GET")
@@ -84,14 +77,14 @@ func buildRouter(cfg *config.Config, authMiddleware JWTValidator) *mux.Router {
 	authRouter.HandleFunc("/logout", authProxy.HandleLogout).Methods("POST")
 
 	// Routes user (protégées par JWT)
-	userRouter := r.PathPrefix("/api/v1/user").Subrouter()
+	userRouter := r.PathPrefix("/api/v1/users").Subrouter()
 	userRouter.Use(authMiddleware.ValidateJWT)
-	userRouter.PathPrefix("/").HandlerFunc(userProxy.ProxyRequest)
+	userRouter.PathPrefix("").HandlerFunc(userProxy.ProxyRequest)
 
 	// Routes messaging (protégées par JWT)
-	messagingRouter := r.PathPrefix("/api/v1/messaging").Subrouter()
+	messagingRouter := r.PathPrefix("/api/v1/conversations").Subrouter()
 	messagingRouter.Use(authMiddleware.ValidateJWT)
-	messagingRouter.PathPrefix("/").HandlerFunc(messagingProxy.ProxyRequest)
+	messagingRouter.PathPrefix("").HandlerFunc(messagingProxy.ProxyRequest)
 
 	// Catch-all pour routes inconnues
 	r.NotFoundHandler = http.HandlerFunc(notFoundHandler)
@@ -138,8 +131,16 @@ func main() {
 
 	r := buildRouter(cfg, authMiddleware)
 
+	// Appliquer CORS au niveau serveur (wrappe tout, y compris NotFoundHandler)
+	var handler http.Handler = r
+	corsOrigin := resolveCORSOrigin(cfg)
+	if corsOrigin != "" {
+		handler = corsMiddleware(corsOrigin)(r)
+		log.Printf("[CORS] Middleware active with origin %q", corsOrigin)
+	}
+
 	// Configuration du serveur
-	srv := newHTTPServer(cfg, loggingMiddleware(r))
+	srv := newHTTPServer(cfg, loggingMiddleware(handler))
 
 	// Démarrage du serveur
 	go func() {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2,20 +2,25 @@ package proxy
 
 import (
 	"net/http"
+	"strings"
 )
 
 // ServiceProxy gère le proxy vers un microservice générique.
 type ServiceProxy struct {
-	serviceURL string
+	serviceURL  string
+	stripPrefix string
 }
 
 // NewServiceProxy crée un nouveau ServiceProxy pointant vers serviceURL.
-func NewServiceProxy(serviceURL string) *ServiceProxy {
-	return &ServiceProxy{serviceURL: serviceURL}
+// stripPrefix est le préfixe gateway à retirer avant de transmettre au service.
+func NewServiceProxy(serviceURL, stripPrefix string) *ServiceProxy {
+	return &ServiceProxy{serviceURL: serviceURL, stripPrefix: stripPrefix}
 }
 
-// ProxyRequest transmet la requête vers le microservice cible.
+// ProxyRequest transmet la requête vers le microservice cible
+// en retirant le préfixe gateway du chemin.
 func (sp *ServiceProxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
-	target := sp.serviceURL + r.URL.Path
+	path := strings.TrimPrefix(r.URL.Path, sp.stripPrefix)
+	target := sp.serviceURL + path
 	doReverseProxy(target, w, r)
 }

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -8,9 +8,12 @@ import (
 )
 
 func TestNewServiceProxy(t *testing.T) {
-	proxy := NewServiceProxy("http://user:8083")
+	proxy := NewServiceProxy("http://user:8083", "/api/v1")
 	if proxy.serviceURL != "http://user:8083" {
 		t.Errorf("Expected serviceURL to be http://user:8083, got %s", proxy.serviceURL)
+	}
+	if proxy.stripPrefix != "/api/v1" {
+		t.Errorf("Expected stripPrefix to be /api/v1, got %s", proxy.stripPrefix)
 	}
 }
 
@@ -28,7 +31,7 @@ func TestServiceProxyRequest_Success(t *testing.T) {
 	}))
 	defer mockService.Close()
 
-	proxy := NewServiceProxy(mockService.URL)
+	proxy := NewServiceProxy(mockService.URL, "/api/v1")
 
 	req := httptest.NewRequest("GET", "/api/v1/user/profile", nil)
 	req.Header.Set("X-User-ID", "user-123")
@@ -61,7 +64,7 @@ func TestServiceProxyRequest_PreservesHeaders(t *testing.T) {
 	}))
 	defer mockService.Close()
 
-	proxy := NewServiceProxy(mockService.URL)
+	proxy := NewServiceProxy(mockService.URL, "/api/v1")
 
 	req := httptest.NewRequest("GET", "/api/v1/user/profile", nil)
 	req.Header.Set("X-User-ID", "user-123")
@@ -86,7 +89,7 @@ func TestServiceProxyRequest_WithQueryParams(t *testing.T) {
 	}))
 	defer mockService.Close()
 
-	proxy := NewServiceProxy(mockService.URL)
+	proxy := NewServiceProxy(mockService.URL, "/api/v1")
 
 	req := httptest.NewRequest("GET", "/api/v1/user/list?page=1&limit=10", nil)
 	rr := httptest.NewRecorder()
@@ -108,7 +111,7 @@ func TestServiceProxyRequest_POST(t *testing.T) {
 	}))
 	defer mockService.Close()
 
-	proxy := NewServiceProxy(mockService.URL)
+	proxy := NewServiceProxy(mockService.URL, "/api/v1")
 
 	req := httptest.NewRequest("POST", "/api/v1/user", strings.NewReader(`{"name":"Bob"}`))
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
…hing

r.Use() in gorilla/mux only runs middleware for matched routes — preflight OPTIONS requests hitting NotFoundHandler got no CORS headers. Move CORS middleware to wrap the entire router at the HTTP server level.

Also fix subrouter PathPrefix("/") → PathPrefix("") so routes without trailing slash (e.g. /api/v1/users) are matched correctly, and correct route prefixes to match actual service paths (/users, /conversations).