### PR TITLE
feat(proxy): resolve /me path segment to actual user ID from JWT

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -18,9 +18,27 @@ func NewServiceProxy(serviceURL, stripPrefix string) *ServiceProxy {
 }
 
 // ProxyRequest transmet la requête vers le microservice cible
-// en retirant le préfixe gateway du chemin.
+// en retirant le préfixe gateway du chemin et en résolvant "/me" en ID réel.
 func (sp *ServiceProxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, sp.stripPrefix)
+	if userID := r.Header.Get("X-User-ID"); userID != "" {
+		path = resolveMe(path, userID)
+	}
 	target := sp.serviceURL + path
 	doReverseProxy(target, w, r)
+}
+
+// resolveMe remplace le segment de chemin "/me" par "/{userID}".
+// Seul le segment exact "/me" est remplacé (pas "/meeting", "/me-too", etc.).
+func resolveMe(path, userID string) string {
+	// Fin de path : "/users/me" → "/users/{userID}"
+	if strings.HasSuffix(path, "/me") {
+		rest := path[:len(path)-3] // tout sauf "/me"
+		return rest + "/" + userID
+	}
+	// Milieu de path : "/users/me/avatar" → "/users/{userID}/avatar"
+	if idx := strings.Index(path, "/me/"); idx >= 0 {
+		return path[:idx] + "/" + userID + "/" + path[idx+4:]
+	}
+	return path
 }

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -123,3 +123,88 @@ func TestServiceProxyRequest_POST(t *testing.T) {
 		t.Errorf("Expected status 201, got %d", rr.Code)
 	}
 }
+
+// =============================================================================
+// resolveMe
+// =============================================================================
+
+func TestResolveMe_EndOfPath(t *testing.T) {
+	got := resolveMe("/users/me", "abc-123")
+	if got != "/users/abc-123" {
+		t.Errorf("expected /users/abc-123, got %s", got)
+	}
+}
+
+func TestResolveMe_MiddleOfPath(t *testing.T) {
+	got := resolveMe("/users/me/avatar", "abc-123")
+	if got != "/users/abc-123/avatar" {
+		t.Errorf("expected /users/abc-123/avatar, got %s", got)
+	}
+}
+
+func TestResolveMe_NoMatch_Meeting(t *testing.T) {
+	got := resolveMe("/users/meeting", "abc-123")
+	if got != "/users/meeting" {
+		t.Errorf("expected /users/meeting (unchanged), got %s", got)
+	}
+}
+
+func TestResolveMe_NoMatch_MeToo(t *testing.T) {
+	got := resolveMe("/users/me-too", "abc-123")
+	if got != "/users/me-too" {
+		t.Errorf("expected /users/me-too (unchanged), got %s", got)
+	}
+}
+
+func TestResolveMe_JustMe(t *testing.T) {
+	got := resolveMe("/me", "abc-123")
+	if got != "/abc-123" {
+		t.Errorf("expected /abc-123, got %s", got)
+	}
+}
+
+func TestServiceProxyRequest_ResolvesMe(t *testing.T) {
+	mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users/user-uuid-456" {
+			t.Errorf("Expected path /users/user-uuid-456, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockService.Close()
+
+	proxy := NewServiceProxy(mockService.URL, "/api/v1")
+
+	req := httptest.NewRequest("PUT", "/api/v1/users/me", strings.NewReader(`{"username":"alice"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", "user-uuid-456")
+	rr := httptest.NewRecorder()
+
+	proxy.ProxyRequest(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rr.Code)
+	}
+}
+
+func TestServiceProxyRequest_NoUserID_KeepsMe(t *testing.T) {
+	mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users/me" {
+			t.Errorf("Expected path /users/me (unchanged), got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockService.Close()
+
+	proxy := NewServiceProxy(mockService.URL, "/api/v1")
+
+	req := httptest.NewRequest("GET", "/api/v1/users/me", nil)
+	// No X-User-ID header
+	rr := httptest.NewRecorder()
+
+	proxy.ProxyRequest(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
The gateway JWT middleware already injects X-User-ID into downstream requests. This change rewrites /me → /{userID} in ServiceProxy before forwarding, so PUT /api/v1/users/me reaches the User Service as PUT /users/{uuid} and the onboarding profile update works.