### PR TITLE
feat(ws): add WebSocket proxy endpoint with JWT auth

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -86,6 +86,17 @@ func buildRouter(cfg *config.Config, authMiddleware JWTValidator) *mux.Router {
 	messagingRouter.Use(authMiddleware.ValidateJWT)
 	messagingRouter.PathPrefix("").HandlerFunc(messagingProxy.ProxyRequest)
 
+	// Route messages by ID (protégée par JWT)
+	messagesRouter := r.PathPrefix("/api/v1/messages").Subrouter()
+	messagesRouter.Use(authMiddleware.ValidateJWT)
+	messagesRouter.PathPrefix("").HandlerFunc(messagingProxy.ProxyRequest)
+
+	// WebSocket (protégé par JWT, proxy vers messaging service)
+	wsProxy := proxy.NewWebSocketProxy(cfg.MessagingServiceURL)
+	wsRouter := r.PathPrefix("/api/v1/ws").Subrouter()
+	wsRouter.Use(authMiddleware.ValidateJWT)
+	wsRouter.HandleFunc("", wsProxy.ProxyWS)
+
 	// Catch-all pour routes inconnues
 	r.NotFoundHandler = http.HandlerFunc(notFoundHandler)
 

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/gorilla/mux v1.8.1
 require (
 	github.com/MicahParks/keyfunc/v2 v2.1.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -1,0 +1,115 @@
+package proxy
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true // CORS is handled by the gateway middleware
+	},
+}
+
+// WebSocketProxy proxies WebSocket connections to a backend service.
+type WebSocketProxy struct {
+	backendURL string
+}
+
+// NewWebSocketProxy creates a new WebSocket proxy targeting backendURL.
+func NewWebSocketProxy(backendURL string) *WebSocketProxy {
+	return &WebSocketProxy{backendURL: backendURL}
+}
+
+// ProxyWS upgrades the client connection and dials the backend,
+// then pipes frames bidirectionally.
+// The X-User-ID header must already be set by the auth middleware.
+func (wsp *WebSocketProxy) ProxyWS(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Build backend WS URL
+	backendWS := strings.Replace(wsp.backendURL, "http://", "ws://", 1)
+	backendWS = strings.Replace(backendWS, "https://", "wss://", 1)
+
+	backendURL, err := url.Parse(backendWS + "/ws")
+	if err != nil {
+		log.Printf("WS proxy: invalid backend URL: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Forward query params
+	backendURL.RawQuery = r.URL.RawQuery
+
+	// Dial backend with X-User-ID header
+	backendHeaders := http.Header{}
+	backendHeaders.Set("X-User-ID", userID)
+
+	backendConn, resp, err := websocket.DefaultDialer.Dial(backendURL.String(), backendHeaders)
+	if err != nil {
+		if resp != nil {
+			log.Printf("WS proxy: backend dial failed (status %d): %v", resp.StatusCode, err)
+		} else {
+			log.Printf("WS proxy: backend dial failed: %v", err)
+		}
+		http.Error(w, "Backend unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	defer backendConn.Close()
+
+	// Upgrade client connection
+	clientConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("WS proxy: client upgrade failed: %v", err)
+		return
+	}
+	defer clientConn.Close()
+
+	log.Printf("WS proxy: connection established for user %s", userID)
+
+	errc := make(chan error, 2)
+
+	// Client → Backend
+	go func() {
+		for {
+			msgType, msg, err := clientConn.ReadMessage()
+			if err != nil {
+				errc <- err
+				return
+			}
+			if err := backendConn.WriteMessage(msgType, msg); err != nil {
+				errc <- err
+				return
+			}
+		}
+	}()
+
+	// Backend → Client
+	go func() {
+		for {
+			msgType, msg, err := backendConn.ReadMessage()
+			if err != nil {
+				errc <- err
+				return
+			}
+			if err := clientConn.WriteMessage(msgType, msg); err != nil {
+				errc <- err
+				return
+			}
+		}
+	}()
+
+	// Wait for either direction to fail
+	<-errc
+	log.Printf("WS proxy: connection closed for user %s", userID)
+}


### PR DESCRIPTION
Add /api/v1/ws route that upgrades HTTP to WebSocket, authenticates via JWT middleware, and proxies frames bidirectionally to the messaging service. Also add /api/v1/messages route for message update/delete endpoints.