### PR TITLE
fix(auth): accept JWT token as query parameter for WebSocket

### DIFF
--- a/internal/middleware/auth_jwks.go
+++ b/internal/middleware/auth_jwks.go
@@ -39,15 +39,20 @@ func NewAuthMiddlewareJWKS(jwksURL, jwtIssuer string) (*AuthMiddlewareJWKS, erro
 
 func (am *AuthMiddlewareJWKS) ValidateJWT(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authHeader := r.Header.Get(headerAuth)
-		if authHeader == "" {
-			http.Error(w, "Authorization header required", http.StatusUnauthorized)
-			return
-		}
+		var tokenString string
 
-		tokenString := strings.TrimPrefix(authHeader, bearerPrefix)
-		if tokenString == authHeader {
-			http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
+		authHeader := r.Header.Get(headerAuth)
+		if authHeader != "" {
+			tokenString = strings.TrimPrefix(authHeader, bearerPrefix)
+			if tokenString == authHeader {
+				http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
+				return
+			}
+		} else if qToken := r.URL.Query().Get("token"); qToken != "" {
+			// WebSocket connections cannot send headers; accept token as query param
+			tokenString = qToken
+		} else {
+			http.Error(w, "Authorization header required", http.StatusUnauthorized)
 			return
 		}
 


### PR DESCRIPTION
WebSocket connections cannot send custom headers during the upgrade handshake. Allow the token to be passed via ?token= query parameter as a fallback when the Authorization header is absent.